### PR TITLE
fix: use valid Tailwind transition duration

### DIFF
--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -13,7 +13,7 @@ const ResultCard: React.FC<ResultCardProps> = ({ result, visible }) => {
 
   return (
     <div className={`
-      opacity-0 transform translate-y-5 scale-95 transition-all duration-400 ease-in-out
+      opacity-0 transform translate-y-5 scale-95 transition-all duration-300 ease-in-out
       ${visible ? 'opacity-100 translate-y-0 scale-100' : ''}
       grid grid-cols-1 gap-6
     `}>


### PR DESCRIPTION
## Summary
- replace `duration-400` with Tailwind-supported `duration-300` in `ResultCard`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `npm run build`
- `npm run dev` (visual check)


------
https://chatgpt.com/codex/tasks/task_e_6896fce965d4832d8f828196badcf4cb