### PR TITLE
Add time calculation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+build
 *.local
 
 # Editor directories and files

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npx tsc tests/timeCalculations.test.ts src/utils/timeCalculations.ts src/types/index.ts --module ES2020 --moduleResolution node --target ES2019 --outDir build --rootDir . && node --test build/tests/timeCalculations.test.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",

--- a/tests/timeCalculations.test.ts
+++ b/tests/timeCalculations.test.ts
@@ -1,0 +1,15 @@
+// @ts-nocheck
+import test from 'node:test';
+import assert from 'node:assert';
+import { calculateExitTime } from '../src/utils/timeCalculations.js';
+
+test('correzione dell\'orario di uscita a 16:15 in modalità 7h12 con pausa', () => {
+  const result = calculateExitTime('08:00', '7h12', true, false);
+  assert.strictEqual(result?.exitTime, '16:15');
+  assert.strictEqual(result?.warning, 'Uscita minima per buono pasto: 16:15');
+});
+
+test('aggiunta di 30 minuti di straordinario quando overtimeEnabled è true', () => {
+  const result = calculateExitTime('09:00', '6h', false, true);
+  assert.strictEqual(result?.exitTime, '15:30');
+});


### PR DESCRIPTION
## Summary
- add unit tests for exit time correction and overtime
- configure npm test script and ignore build artifacts

## Testing
- `npm test`
- `npm run lint` (fails: Cannot read properties of undefined (reading 'allowShortCircuit'))

------
https://chatgpt.com/codex/tasks/task_e_6896fece71a8832daefd1152a158d6a5