### PR TITLE
Remove warning rendering from ResultCard

### DIFF
--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CalculationResult } from '../types';
 
 interface ResultCardProps {
-  result: CalculationResult | null;
+  result: Omit<CalculationResult, 'warning'> | null;
   visible: boolean;
 }
 
@@ -21,12 +21,6 @@ const ResultCard: React.FC<ResultCardProps> = ({ result, visible }) => {
         <div className="text-xl font-semibold mb-5 opacity-90">
           {result.title}
         </div>
-        
-        {result.warning && (
-          <div className="text-sm text-yellow-400 -mt-4 mb-4 font-medium">
-            {result.warning}
-          </div>
-        )}
         
         <div className="text-4xl font-bold font-mono mb-6 text-pink-300 drop-shadow-lg">
           {result.exitTime}


### PR DESCRIPTION
## Summary
- avoid expecting a warning field in ResultCard results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68970149cd48832d91b2743ed06d4e44