### PR TITLE
Remove minimum exit warning

### DIFF
--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -22,12 +22,6 @@ const ResultCard: React.FC<ResultCardProps> = ({ result, visible }) => {
           {result.title}
         </div>
         
-        {result.warning && (
-          <div className="text-sm text-yellow-400 -mt-4 mb-4 font-medium">
-            {result.warning}
-          </div>
-        )}
-        
         <div className="text-4xl font-bold font-mono mb-6 text-pink-300 drop-shadow-lg">
           {result.exitTime}
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,6 @@ export interface CalculationResult {
   workedTime: string;
   breakTime: string;
   title: string;
-  warning?: string;
 }
 
 export interface ToggleOptionProps {

--- a/src/utils/timeCalculations.ts
+++ b/src/utils/timeCalculations.ts
@@ -38,7 +38,6 @@ export const calculateExitTime = (
   let targetWorkMinutes = 0;
   let breakMinutes = 0;
   let resultTitle = '';
-  let warningMessage = '';
 
   // Determine target work time and break based on mode
   switch (mode) {
@@ -77,13 +76,6 @@ export const calculateExitTime = (
     resultTitle += ' + Straordinario';
   }
 
-  // Meal Voucher Validation & Correction
-  const minExitTimeMinutes = 16 * 60 + 15; // 16:15
-  if (mode === '7h12' && lunchBreakEnabled && exitTotalMinutes < minExitTimeMinutes) {
-    warningMessage = `Uscita minima per buono pasto: 16:15`;
-    exitTotalMinutes = minExitTimeMinutes;
-  }
-  
   const exitDate = new Date();
   exitDate.setHours(Math.floor(exitTotalMinutes / 60), exitTotalMinutes % 60, 0, 0);
 
@@ -91,7 +83,6 @@ export const calculateExitTime = (
     exitTime: formatTime(exitDate),
     workedTime: minutesToHM(targetWorkMinutes),
     breakTime: minutesToHM(breakMinutes),
-    title: resultTitle,
-    warning: warningMessage || undefined
+    title: resultTitle
   };
 };


### PR DESCRIPTION
## Summary
- remove minimum exit time warning and related strings
- clean up types and components to drop unused warning field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68970148f778832da79680095b093362