### PR TITLE
Remove warning property from calculation result

### DIFF
--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -21,13 +21,7 @@ const ResultCard: React.FC<ResultCardProps> = ({ result, visible }) => {
         <div className="text-xl font-semibold mb-5 opacity-90">
           {result.title}
         </div>
-        
-        {result.warning && (
-          <div className="text-sm text-yellow-400 -mt-4 mb-4 font-medium">
-            {result.warning}
-          </div>
-        )}
-        
+
         <div className="text-4xl font-bold font-mono mb-6 text-pink-300 drop-shadow-lg">
           {result.exitTime}
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,6 @@ export interface CalculationResult {
   workedTime: string;
   breakTime: string;
   title: string;
-  warning?: string;
 }
 
 export interface ToggleOptionProps {

--- a/src/utils/timeCalculations.ts
+++ b/src/utils/timeCalculations.ts
@@ -38,7 +38,6 @@ export const calculateExitTime = (
   let targetWorkMinutes = 0;
   let breakMinutes = 0;
   let resultTitle = '';
-  let warningMessage = '';
 
   // Determine target work time and break based on mode
   switch (mode) {
@@ -80,7 +79,6 @@ export const calculateExitTime = (
   // Meal Voucher Validation & Correction
   const minExitTimeMinutes = 16 * 60 + 15; // 16:15
   if (mode === '7h12' && lunchBreakEnabled && exitTotalMinutes < minExitTimeMinutes) {
-    warningMessage = `Uscita minima per buono pasto: 16:15`;
     exitTotalMinutes = minExitTimeMinutes;
   }
   
@@ -91,7 +89,6 @@ export const calculateExitTime = (
     exitTime: formatTime(exitDate),
     workedTime: minutesToHM(targetWorkMinutes),
     breakTime: minutesToHM(breakMinutes),
-    title: resultTitle,
-    warning: warningMessage || undefined
+    title: resultTitle
   };
 };


### PR DESCRIPTION
## Summary
- remove `warning` field from `CalculationResult` type
- drop warning display in `ResultCard`
- streamline `calculateExitTime` logic to adjust exit time without warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_689701496a54832daf3c84e8cb7ec166