### PR TITLE
Validate entry time input

### DIFF
--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -4,10 +4,11 @@ import { CalculationResult } from '../types';
 interface ResultCardProps {
   result: Omit<CalculationResult, 'warning'> | null;
   visible: boolean;
+  entryTimeError?: string;
 }
 
-const ResultCard: React.FC<ResultCardProps> = ({ result, visible }) => {
-  if (!visible || !result) {
+const ResultCard: React.FC<ResultCardProps> = ({ result, visible, entryTimeError }) => {
+  if (!visible || !result || entryTimeError) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- add entry time validation and error state
- hide results when entry time invalid

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68972d5925d8832d91973a5af0160d48