### PR TITLE
chore: refresh browserslist data before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "npx tsc tests/timeCalculations.test.ts src/utils/timeCalculations.ts src/types/index.ts --module ES2020 --moduleResolution node --target ES2019 --outDir build --rootDir . && node --test build/tests/timeCalculations.test.js"
+    "test": "npx tsc tests/timeCalculations.test.ts src/utils/timeCalculations.ts src/types/index.ts --module ES2020 --moduleResolution node --target ES2019 --outDir build --rootDir . && node --test build/tests/timeCalculations.test.js",
+    "prebuild": "npx update-browserslist-db@latest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",


### PR DESCRIPTION
## Summary
- update build pipeline to refresh Browserslist data before compiling

## Testing
- `npm test`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/update-browserslist-db)*

------
https://chatgpt.com/codex/tasks/task_e_689730bd28e8832dbf3f55f3858c79cf